### PR TITLE
請求書詳細画面改善

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,21 +1,26 @@
+// src/App.tsx
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import InvoiceList from './components/InvoiceList';
-import NewInvoice from './components/NewInvoice';  // 新しいコンポーネントをインポート
-import EditInvoice from './components/EditInvoice'; // ← 新しい編集ページをインポート
+import NewInvoice from './components/NewInvoice';
+import EditInvoice from './components/EditInvoice';
+import InvoiceDetails from './components/InvoiceDetails';
+import { InvoiceProvider } from './context/InvoiceContext'; // InvoiceProviderをインポート
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <Routes>
-        {/* 請求書リストページ */}
-        <Route path="/" element={<InvoiceList />} />
-        {/* 新規請求書作成ページ */}
-        <Route path="/new-invoice" element={<NewInvoice />} />
-        <Route path="/edit-invoice/:id" element={<EditInvoice />} /> {/* ← 編集ページのルート */}
-      </Routes>
-    </Router>
+    <InvoiceProvider>  {/* アプリ全体をProviderでラップ */}
+      <Router>
+        <Routes>
+          <Route path="/" element={<InvoiceList />} />
+          <Route path="/new-invoice" element={<NewInvoice />} />
+          <Route path="/edit-invoice/:id" element={<EditInvoice />} />
+          <Route path="/invoice-details/:invoiceNumber" element={<InvoiceDetails />} />
+        </Routes>
+      </Router>
+    </InvoiceProvider>
   );
 };
 
 export default App;
+

--- a/my-app/src/components/InvoiceDetails.css
+++ b/my-app/src/components/InvoiceDetails.css
@@ -1,55 +1,63 @@
-.invoice-details-title {
-    font-size: 1.5rem;
-    margin-bottom: 10px;
-    color: #555;
-  }
-  
-  .invoice-items {
-    list-style-type: none;
-    padding: 0;
-  }
-  
-  .invoice-item {
-    padding: 10px;
-    border-bottom: 1px solid #ddd;
-  }
-  
-  .invoice-item:last-child {
-    border-bottom: none;
-  }
- /* ページ全体のスタイル */
-body {
-  font-family: Arial, sans-serif;
-  background-color: #f9f9f9;
-  color: #333;
-  margin: 0;
-  padding: 0;
+/* ページ全体のスタイル */
+.invoice-details-page {
+  background-color: #f0f0f0; /* 背景を薄いグレーに */
+  padding: 40px 0; /* 上下の余白を追加 */
 }
 
-.container {
-  max-width: 1000px;
-  margin: 40px auto;
-  padding: 20px;
-  background-color: white;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-h1, h2 {
-  text-align: center;
-  color: #333;
-}
-
-p {
-  text-align: center;
-}
-
-/* 請求書詳細の全体コンテナに背景色とボーダーを追加 */
 .invoice-details-container {
-  background-color: #f9f9f9;  /* 薄いグレーの背景色 */
-  padding: 20px;              /* 内側の余白を広げる */
-  border: 1px solid #ddd;      /* 周囲に薄いボーダーを追加 */
-  border-radius: 10px;         /* 四隅を丸くする */
-  margin-bottom: 20px;         /* 下に余白を追加 */
+  max-width: 800px; /* 横幅を調整して中央に配置 */
+  margin: 0 auto; /* 中央寄せ */
+  padding: 20px;
+  background-color: white; /* 白い背景 */
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 影を追加 */
+}
+
+/* テーブル形式で表示 */
+.invoice-details-table {
+  width: 100%;
+  border-collapse: collapse; /* テーブルのボーダーを一体化 */
+  margin-bottom: 20px;
+}
+
+.invoice-details-table th, .invoice-details-table td {
+  padding: 10px;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+.invoice-details-table th {
+  background-color: #f8f8f8; /* ヘッダーの背景色を薄いグレーに */
+  font-weight: bold;
+  width: 150px; /* 左側の項目名の列の幅を固定 */
+}
+
+.invoice-details-table td {
+  background-color: white; /* ヘッダー以外のセルの背景を白に */
+}
+
+.invoice-details-table td {
+  text-align: left; /* 値の部分を左揃えに */
+}
+
+/* 項目リストのデザイン */
+.invoice-item-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.invoice-item-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid #ddd;
+}
+
+/* 合計金額のデザイン */
+.invoice-total {
+  font-weight: bold;
+  font-size: 18px;
+  text-align: right; /* 合計金額を右揃え */
+  margin-top: 20px;
 }
 
 /* タイトルのデザインを強調 */
@@ -58,6 +66,7 @@ p {
   margin-bottom: 10px;         /* タイトルの下に余白 */
   border-bottom: 2px solid #333; /* タイトル下に太めのボーダーを追加 */
   padding-bottom: 5px;         /* タイトルとボーダーの間に少し余白 */
+  text-align: left;            /* タイトルを左揃えにする */
 }
 
 /* 各項目のデザイン */
@@ -77,9 +86,55 @@ p {
   border-bottom: 1px solid #ddd; /* 項目間にボーダーを追加 */
 }
 
+/* 項目リストの金額にカンマを追加 */
+.invoice-item-list li .amount, .invoice-item-list li .tax {
+  font-weight: bold;
+}
+
 /* 合計金額のデザイン */
 .invoice-total {
   font-weight: bold;            /* 太字にする */
   font-size: 18px;              /* 文字サイズを少し大きく */
   margin-top: 10px;             /* 上に余白を追加 */
+  text-align: right;            /* 合計金額を右揃えにする */
+}
+
+/* テーブル風のスタイルを追加して請求書詳細情報を整理 */
+.invoice-details {
+  display: table;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.invoice-details p {
+  display: table-row;
+}
+
+.invoice-details p span {
+  display: table-cell;
+  padding: 5px 10px;
+  border-bottom: 1px solid #ddd;
+}
+
+.invoice-details p span:first-child {
+  font-weight: bold;
+  width: 200px; /* 左側の項目名の幅を固定 */
+}
+
+/* 請求書詳細テーブルのヘッダー部分の色を薄いグレーに変更 */
+.invoice-details-header {
+  background-color: #f0f0f0;
+  font-weight: bold;
+  padding: 10px;
+  text-align: left;
+  border-bottom: 1px solid #ccc;
+}
+
+/* 請求書リストのボタンの間に余白を追加 */
+.edit-btn, .details-btn, .delete-btn {
+  margin-bottom: 5px;  /* ボタンの下に余白を追加 */
+}
+
+.edit-btn {
+  margin-right: 5px;   /* 編集ボタンと削除ボタンの間に横の余白を追加 */
 }

--- a/my-app/src/components/InvoiceDetails.tsx
+++ b/my-app/src/components/InvoiceDetails.tsx
@@ -1,35 +1,38 @@
 // src/components/InvoiceDetails.tsx
 import React, { useContext } from 'react';
+import { useParams } from 'react-router-dom';
 import { InvoiceContext } from '../context/InvoiceContext';
-import './InvoiceDetails.css';  // CSSファイルのインポート
+import './InvoiceDetails.css';
 
 const InvoiceDetails: React.FC = () => {
-  const context = useContext(InvoiceContext);
-  if (!context) throw new Error('InvoiceDetails must be used within an InvoiceProvider');
+  const { invoiceNumber } = useParams<{ invoiceNumber: string }>();
+  const { invoices } = useContext(InvoiceContext) || { invoices: [] };
 
-  const { selectedInvoice } = context;  // selectedInvoiceを取得
+// 該当する請求書を探す  
+  const selectedInvoice = invoices.find((invoice) => invoice.invoiceNumber === invoiceNumber);
 
   if (!selectedInvoice) {
-    return <p>請求書が選択されていません。請求書を選んでください。</p>;
+    return <p>該当する請求書が見つかりません。</p>;
   }
 
   return (
     <div className="invoice-details-container">
-      <h2>請求書詳細</h2>
-      <p>会社名: {selectedInvoice.companyName}</p>
-      <p>登録番号: {selectedInvoice.registrationNumber}</p>
-      <p>請求書番号: {selectedInvoice.invoiceNumber}</p>
-      <p>請求日: {selectedInvoice.invoiceDate}</p>
-      <p>支払期限: {selectedInvoice.paymentDue}</p>
+      <h2>請求書詳細ページ</h2>
+      <div className="invoice-details">
+        <p>請求書番号: {selectedInvoice.invoiceNumber}</p>
+        <p>会社名: {selectedInvoice.companyName}</p>
+        <p>請求日: {selectedInvoice.invoiceDate}</p>
+        <p>支払期限: {selectedInvoice.paymentDue}</p>
+      </div>
       <h3>項目リスト</h3>
       <ul className="invoice-item-list">
         {selectedInvoice.items.map((item, index) => (
           <li key={index}>
-            {item.itemName} - {item.amount}円（消費税: {item.tax}円） - 合計: {item.getTotal()}円
+            {item.itemName}: {item.amount.toLocaleString()}円 (税: {item.tax.toLocaleString()}円)
           </li>
         ))}
       </ul>
-      <p className="invoice-total">合計金額: {selectedInvoice.totalAmount}円</p>
+      <p className="invoice-total">合計金額: {selectedInvoice.totalAmount.toLocaleString()}円</p>
     </div>
   );
 };

--- a/my-app/src/components/InvoiceList.css
+++ b/my-app/src/components/InvoiceList.css
@@ -2,8 +2,14 @@
 .page-container {
   padding: 20px;
   background-color: #f0f0f0; /* 薄いグレー */
-  max-width: 1200px;
+  max-width: 1200px; /* 横幅をテーブルに合わせる */
   margin: 0 auto; /* 画面中央に余白 */
+}
+
+/* タイトルを左揃えにする */
+.page-container h1 {
+  font-size: 24px;
+  text-align: left; /* 左揃えに修正 */
 }
 
 /* タイトル文字サイズを小さくする */
@@ -11,23 +17,32 @@
   font-size: 24px; /* 少し小さめに調整 */
 }
 
-/* 検索ボックスと検索ボタンの配置 */
+/* container全体をテーブルと同じ幅に合わせる */
 .container {
   display: flex;
-  justify-content: space-between; /* 左に検索ボックス、右に新規作成ボタン */
+  justify-content: space-between;
   align-items: center;
-  padding: 20px 0; /* 上下に余白 */
+  padding: 20px 0;
+  background-color: white;  /* 白い背景 */
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 1200px;  /* テーブルと揃えて1200pxに設定 */
+  margin-bottom: 20px; /* テーブルとの余白 */
+  box-sizing: border-box;  /* パディングを含めた幅調整 */
 }
 
-/* 検索ボックスと検索ボタンのデザイン */
+/* 検索ボックスと検索ボタンを左揃えに */
 .search-container {
   display: flex;
+  justify-content: flex-start; /* 左揃えに変更 */
   align-items: center;
+  gap: 5px; /* ボタンと検索ボックスの間の余白 */
 }
 
 .search-container input {
   height: 25px; 
-  width: 500px; /* 横幅 */
+  width: 600px; /* 横幅 */
   border-radius: 4px;
   border: 1px solid #ccc;
   padding: 10px;
@@ -54,6 +69,7 @@
   font-size: 14px;
   cursor: pointer;
   border-radius: 4px;
+  margin-left: auto; /* 右端に揃える */
 }
 
 /* テーブルセルの背景色を白にする */
@@ -75,52 +91,129 @@
   font-weight: bold;
 }
 
+/* 各列の幅設定 */
+.table-container th:first-child, .table-container td:first-child {
+  width: 5%; /* チェックボックス列の幅 */
+}
+
+.table-container th:nth-child(2), .table-container td:nth-child(2) {
+  width: 10%; /* 請求書番号の列を狭く */
+}
+
+.table-container th:nth-child(3), .table-container td:nth-child(3) {
+  width: 35%; /* 取引先の列を広く */
+}
+
+.table-container th:nth-child(4), .table-container td:nth-child(4) {
+  width: 10%; /* 請求日の列 */
+}
+
+.table-container th:nth-child(5), .table-container td:nth-child(5) {
+  width: 10%; /* 支払期限の列 */
+}
+
+.table-container th:nth-child(6), .table-container td:nth-child(6) {
+  width: 10%; /* 合計金額の列 */
+}
+
+.table-container th:nth-child(7), .table-container td:nth-child(7) {
+  width: 15%; /* 操作の列 */
+}
+
+/* 編集・削除ボタン */
 .edit-btn {
   background-color: #007bff;
   color: white;
   border: none;
-  padding: 10px 20px;
+  padding: 8px 20px;
   cursor: pointer;
   border-radius: 4px;
-  margin-right: 5px;
+  margin-right: 10px;
+  margin-bottom: 10px; /* 下に余白を追加 */
 }
 
 .delete-btn {
   background-color: #dc3545;
   color: white;
   border: none;
-  padding: 10px 20px;
+  padding: 8px 20px;
+  cursor: pointer;
+  border-radius: 4px;
+  margin-right: 10px;  /* 右側の余白を追加 */
+}
+
+.details-btn {
+  background-color: #1c3d5a;
+  color: white;
+  border: none;
+  padding: 8px 20px;
   cursor: pointer;
   border-radius: 4px;
 }
 
-/* 請求書リストのテーブルスタイル調整 */
+.details-btn:hover {
+  background-color: #162c45;  /* ボタンをホバー時に少し暗く */
+}
+
+/* テーブル全体の幅を整える */
 .table-container th, .table-container td {
-  padding: 10px; /* 余白の調整 */
-  text-align: left; /* 左寄せ */
+  padding: 10px;
+  text-align: left;
 }
 
-/* 各列の幅設定 */
-.table-container th:nth-child(1), .table-container td:nth-child(1) {
-  width: 15%; /* 請求書番号 */
+/* 検索結果テーブルのスタイル */
+.search-results {
+  margin-top: 20px;
 }
 
-.table-container th:nth-child(2), .table-container td:nth-child(2) {
-  width: 25%; /* 取引先 */
+/* 検索結果テーブルの各列の幅を調整 */
+.search-results th:nth-child(1), .search-results td:nth-child(1) {
+  width: 10%; /* 請求書番号 */
 }
 
-.table-container th:nth-child(3), .table-container td:nth-child(3) {
-  width: 15%; /* 請求日 */
+.search-results th:nth-child(2), .search-results td:nth-child(2) {
+  width: 40%; /* 取引先の幅を広くする */
 }
 
-.table-container th:nth-child(4), .table-container td:nth-child(4) {
-  width: 15%; /* 支払期限 */
+.search-results th:nth-child(3), .search-results td:nth-child(3) {
+  width: 10%; /* 請求日の幅を狭くする */
 }
 
-.table-container th:nth-child(5), .table-container td:nth-child(5) {
-  width: 15%; /* 合計金額 */
+.search-results th:nth-child(4), .search-results td:nth-child(4) {
+  width: 10%; /* 支払期限 */
 }
 
-.table-container th:nth-child(6), .table-container td:nth-child(6) {
-  width: 15%; /* 操作 */
+.search-results th:nth-child(5), .search-results td:nth-child(5) {
+  width: 10%; /* 合計金額 */
+}
+
+/* 請求書詳細のタイトルを左揃え */
+.invoice-details-title {
+  text-align: left;
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+
+/* 請求書詳細のテーブルスタイル */
+.invoice-details-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+.invoice-details-table th, .invoice-details-table td {
+  padding: 10px;
+  border: 1px solid #ddd;
+  text-align: left;
+  background-color: #f9f9f9;
+}
+
+.invoice-details-table th {
+  width: 30%;
+  background-color: #f7f7f7;  /* 背景色を薄いグレーに */
+  font-weight: bold;
+}
+
+.invoice-details-table td {
+  width: 70%;
 }

--- a/my-app/src/context/InvoiceContext.tsx
+++ b/my-app/src/context/InvoiceContext.tsx
@@ -1,55 +1,23 @@
 // src/context/InvoiceContext.tsx
 import React, { createContext, useState, ReactNode } from 'react';
-import { Invoice, InvoiceItem } from '../models/InvoiceModel';
+import { invoices } from '../data'; // 仮データをインポート
+import { Invoice } from '../models/InvoiceModel'; // Invoiceモデルをインポート
 
-interface InvoiceProviderProps {
-  children: ReactNode;
-}
+// コンテキストの型定義
+type InvoiceContextType = {
+  invoices: Invoice[];
+  setInvoices: React.Dispatch<React.SetStateAction<Invoice[]>>;
+};
 
-interface InvoiceContextProps {
-  invoices: Invoice[];  // 請求書のリスト
-  selectInvoice: (index: number) => void;
-  selectedInvoice: Invoice | null;  // 選択された請求書
-  deleteInvoice: (index: number) => void;
-}
+// InvoiceContextの作成
+export const InvoiceContext = createContext<InvoiceContextType | undefined>(undefined);
 
-export const InvoiceContext = createContext<InvoiceContextProps | undefined>(undefined);
-
-export const InvoiceProvider: React.FC<InvoiceProviderProps> = ({ children }) => {
-  const [invoices, setInvoices] = useState<Invoice[]>([
-    new Invoice(
-      '株式会社ABC', 'T1234567890123', 'INV-001', '2024-01-01', '2024-01-31',
-      '株式会社ABC', [
-        new InvoiceItem('商品A', 250000, 25000),  // 商品Aのデータ
-        new InvoiceItem('商品B', 300000, 30000)   // 商品Bのデータ
-      ]
-    ),
-    new Invoice(
-      'XYZ商事', 'T9876543210987', 'INV-002', '2024-02-01', '2024-02-28',
-      'XYZ商事', [
-        new InvoiceItem('商品C', 180000, 18000)   // 商品Cのデータ
-      ]
-    ),
-    new Invoice(
-      '株式会社飛田', 'T1239876543210', 'INV-003', '2024-03-01', '2024-03-31',
-      '株式会社飛田', [
-        new InvoiceItem('商品D', 450000, 45000)   // 商品Dのデータ
-      ]
-    )
-  ]);
-
-  const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
-
-  const selectInvoice = (index: number) => {
-    setSelectedInvoice(invoices[index]);  // 請求書を選択
-  };
-
-  const deleteInvoice = (index: number) => {
-    setInvoices((prevInvoices) => prevInvoices.filter((_, i) => i !== index));
-  };
+// InvoiceProviderコンポーネントの作成
+export const InvoiceProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [invoiceData, setInvoiceData] = useState<Invoice[]>(invoices);  // 仮データを初期値として設定
 
   return (
-    <InvoiceContext.Provider value={{ invoices, selectInvoice, selectedInvoice, deleteInvoice }}>
+    <InvoiceContext.Provider value={{ invoices: invoiceData, setInvoices: setInvoiceData }}>
       {children}
     </InvoiceContext.Provider>
   );


### PR DESCRIPTION
data.tsの仮データを引用してアプリケーション全体で使用できるように修正をするというアドバイスをいただき、ChatGPTに指示を伝えながら下記挙動は実装できたと思います。

請求書リスト＞検索実行＞詳細を表示＞詳細ボタンをクリック＞請求書詳細ページに遷移

まだ請求書詳細ページに「戻る」ボタンは設置していません。
また、編集や新規作成後の保存、削除の挙動なども実装できていないため、こちらは進めてまいります。

一旦こちらで見ていただけますでしょうか。
よろしくお願いいたします。